### PR TITLE
JS_Window_SetScrollPos fix

### DIFF
--- a/js_ReaScriptAPI/Source code/js_ReaScriptAPI.cpp
+++ b/js_ReaScriptAPI/Source code/js_ReaScriptAPI.cpp
@@ -1644,12 +1644,16 @@ bool JS_Window_SetScrollPos(void* windowHWND, const char* scrollbar, int positio
 	if (strchr(scrollbar, 'v') || strchr(scrollbar, 'V'))
 	{
 		isOK = !!CoolSB_SetScrollPos((HWND)windowHWND, SB_VERT, position, TRUE);
+		if (!isOK)
+			isOK = !!CoolSB_SetScrollPos((HWND)windowHWND, SB_VERT, position, TRUE);
 		if (isOK)
 			SendMessage((HWND)windowHWND, WM_VSCROLL, MAKEWPARAM(SB_THUMBPOSITION, position), 0);
 	}
 	else
 	{
 		isOK = !!CoolSB_SetScrollPos((HWND)windowHWND, SB_HORZ, position, TRUE);
+		if (!isOK)
+			isOK = !!CoolSB_SetScrollPos((HWND)windowHWND, SB_HORZ, position, TRUE);
 		if (isOK)
 			SendMessage((HWND)windowHWND, WM_HSCROLL, MAKEWPARAM(SB_THUMBPOSITION, position), 0);
 	}


### PR DESCRIPTION
Doesn't work for me in one case, tried this on win7 32bit and win7 64bit:

```
arrange_wnd = reaper.JS_Window_Find("trackview", true)
reaper.JS_Window_SetScrollPos(arrange_wnd, "v", 1000)
```

or

```
arrange_wnd = reaper.JS_Window_Find("trackview", true)
reaper.JS_Window_SetScrollPos(arrange_wnd, "h", 1000)
```

If scrollbar is at 0 position, 
then CoolSB_SetScrollPos returns garbage on 1st execution, 
so only thumb in scrollbar changes position,
but arrange view doesn't move.
If I recall JS_Window_SetScrollPos again, 
then on 2nd execution arrange view changes position, as it should on 1st.

Also, if reaper.TrackList_AdjustWindows is used somewhere around JS_Window_SetScrollPos, 
while scrollbar is at 0 position, i'm not able to change position of scrollbar and arrange view at all.

Looks like a bug in CoolSB_SetScrollPos to me. :)
Maybe you know better way to fix it, but if not, i made workaround.